### PR TITLE
default iterator options reflects wrong abstract-leveldown

### DIFF
--- a/test.js
+++ b/test.js
@@ -543,7 +543,7 @@ test('test iterator() extends', function (t) {
   t.ok(iteratorCalledWith[0] instanceof updown.LevelUPDOWNIterator, 'got expected arguemnt')
   t.deepEqual(
       iteratorCalledWith[0].options
-    , { fillCache: false, keyAsBuffer: true, keyEncoding: 'binary', keys: true, limit: -1, options: 1, reverse: false, valueAsBuffer: true, values: true, valueEncoding: 'binary' }
+    , { keyEncoding: 'binary', options: 1, reverse: false, valueEncoding: 'binary' }
     , 'iterator had expected options'
   )
 


### PR DESCRIPTION
This test fails because it's targeting the wrong version of `abstract-leveldown`. Version `0.12.4` of `abstract-leveldown` does not set `fillCache: false` etc.
